### PR TITLE
Pr/relic scan correctness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,3 @@ debug/
 20??-??-??_??-??-??/
 log.txt
 real-example.png
-
-# Local tessdata overrides (not required in repo)
-src/assets/tesseract/tessdata/eng.traineddata
-src/assets/tesseract/tessdata/osd.traineddata

--- a/src/config/screenshot.py
+++ b/src/config/screenshot.py
@@ -140,7 +140,8 @@ SCREENSHOT_COORDS = {
         },
         RELIC: {
             RELIC_NAME: (0, 0, 0.8, 0.09),
-            RELIC_LEVEL: (0.115, 0.25, 0.28, 0.32),
+            # Left edge must include single-digit "+0" levels, which start near x=0.04.
+            RELIC_LEVEL: (0.03, 0.25, 0.28, 0.32),
             RELIC_DISCARD: (0.865, 0.253, 0.935, 0.293),
             # Centered on the 16:9 relic lock button; keep slightly wider than the icon to absorb scaling drift.
             LOCK: (0.8583333333333333, 0.18171021377672208, 0.9375, 0.22684085510688837),

--- a/src/config/screenshot.py
+++ b/src/config/screenshot.py
@@ -142,7 +142,8 @@ SCREENSHOT_COORDS = {
             RELIC_NAME: (0, 0, 0.8, 0.09),
             RELIC_LEVEL: (0.115, 0.25, 0.28, 0.32),
             RELIC_DISCARD: (0.865, 0.253, 0.935, 0.293),
-            LOCK: (0.865, 0.191, 0.935, 0.23),
+            # Centered on the 16:9 relic lock button; keep slightly wider than the icon to absorb scaling drift.
+            LOCK: (0.8583333333333333, 0.18171021377672208, 0.9375, 0.22684085510688837),
             RELIC_RARITY: (0.07, 0.15, 0.2, 0.22),
             EQUIPPED: (0.45, 0.935, 0.67, 0.965),
             EQUIPPED_AVATAR: (0.3505, 0.916, 0.4375, 0.966675),

--- a/src/services/scanner/parsers/relic_strategy.py
+++ b/src/services/scanner/parsers/relic_strategy.py
@@ -38,7 +38,6 @@ from services.scanner.parsers.parse_strategy import BaseParseStrategy
 from type_defs.stats_dict import RelicDict
 from utils.data import filter_images_from_dict, resource_path
 from utils.ocr import (
-    DIN_ALTERNATE,
     image_to_string,
     preprocess_equipped_img,
     preprocess_level_img,
@@ -265,7 +264,6 @@ class RelicStrategy(BaseParseStrategy):
                 data,
                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ \\'abcedfghijklmnopqrstuvwxyz-",
                 6,
-                lang=f"eng+{DIN_ALTERNATE}",
             )
             if res.endswith(" O"):
                 res = res[:-2].strip()
@@ -278,7 +276,6 @@ class RelicStrategy(BaseParseStrategy):
                     13,
                     True,
                     preprocess_level_img,
-                    lang=f"eng+{DIN_ALTERNATE}",
                 )
                 .replace("S", "5")
                 .replace("+", "")

--- a/src/services/scanner/parsers/relic_strategy.py
+++ b/src/services/scanner/parsers/relic_strategy.py
@@ -102,6 +102,21 @@ class RelicStrategy(BaseParseStrategy):
         except Exception as e:
             self._log(f"Failed to save debug image: {e}", LogLevel.ERROR)
 
+    def _parse_relic_lock_state(self, img: Image) -> bool:
+        """Detect the active/gold relic lock state from the lock button crop."""
+        arr = np.array(img.convert("RGB"))
+        red = arr[:, :, 0]
+        green = arr[:, :, 1]
+        blue = arr[:, :, 2]
+
+        white_ratio = np.mean((red > 220) & (green > 220) & (blue > 220))
+        gold_ratio = np.mean((red > 145) & (green > 105) & (blue < 120))
+        dark_ratio = np.mean((red < 80) & (green < 80) & (blue < 80))
+
+        # Locked relics render as a gold button with a white lock; unlocked relics
+        # render as a white button with a dark lock.
+        return bool(gold_ratio >= 0.45 and white_ratio >= 0.05 and dark_ratio <= 0.03)
+
     def _parse_icon_flag(
         self,
         uid: int,
@@ -129,6 +144,9 @@ class RelicStrategy(BaseParseStrategy):
 
         min_dim = min(haystack.size)
         try:
+            if key == LOCK:
+                return self._parse_relic_lock_state(haystack)
+
             # Normalize mode to avoid locate failures on palette/alpha edge cases.
             icon_img = icon.convert("RGB").resize((min_dim, min_dim))
             haystack_img = haystack.convert("RGB")

--- a/src/services/scanner/scanner.py
+++ b/src/services/scanner/scanner.py
@@ -59,6 +59,7 @@ from models.const import (
 from models.game_data import GameData
 from services.scanner.parsers.parse_strategy import BaseParseStrategy
 from utils.data import resource_path
+from utils.duplicate_capture import recover_duplicate_capture
 from utils.navigation import Navigation
 from utils.ocr import (
     image_to_string,
@@ -84,6 +85,8 @@ class InterruptedScanException(Exception):
 
 class HSRScanner(QObject):
     """HSRScanner class is responsible for scanning the game for light cones, relics, and characters"""
+
+    DUPLICATE_STATS_CAPTURE_RETRY_DELAY = 0.15
 
     update_signal = pyqtSignal(int)
     log_signal = pyqtSignal(object)
@@ -160,6 +163,25 @@ class HSRScanner(QObject):
         time.sleep(0.05)
         self._nav.click()
         self._scan_sleep(0.05)
+
+
+    def _capture_inventory_stats(
+        self,
+        strategy: BaseParseStrategy,
+        item_id: int,
+        previous_stats_panel_bytes: bytes | None,
+    ) -> tuple[dict, bytes]:
+        """Capture inventory stats and recover from repeated stale panel screenshots."""
+        return recover_duplicate_capture(
+            lambda: self._screenshot.screenshot_stats_with_panel_bytes(
+                strategy.SCAN_TYPE
+            ),
+            previous_stats_panel_bytes,
+            item_id,
+            self._log,
+            self._interruptible_sleep,
+            self.DUPLICATE_STATS_CAPTURE_RETRY_DELAY,
+        )
 
     async def start_scan(self) -> dict:
         """Starts the scan
@@ -348,6 +370,7 @@ class HSRScanner(QObject):
 
         tasks = set()
         scanned = 0
+        previous_stats_panel_bytes = None
 
         def should_stop():
             if self._scan_mode == ScanMode.RECENT_RELICS.value:
@@ -360,9 +383,11 @@ class HSRScanner(QObject):
         while not should_stop():
             quantity_remaining -= 1
 
-            # Get stats
-            stats_dict = self._screenshot.screenshot_stats(strategy.SCAN_TYPE)
             item_id = quantity - quantity_remaining
+            stats_dict, stats_panel_bytes = self._capture_inventory_stats(
+                strategy, item_id, previous_stats_panel_bytes
+            )
+            previous_stats_panel_bytes = stats_panel_bytes
 
             # Check if item satisfies filters
             if FILTERS in self._config:
@@ -783,6 +808,19 @@ class HSRScanner(QObject):
         time.sleep(seconds + self._config[CONFIG_SCAN_DELAY])
         if self._interrupt_event.is_set():
             raise InterruptedScanException()
+
+    def _interruptible_sleep(self, seconds: float) -> None:
+        """Sleep without scan/navigation delay, waking early on interruption."""
+        end_time = time.perf_counter() + seconds
+        while True:
+            if self._interrupt_event.is_set():
+                raise InterruptedScanException()
+
+            remaining = end_time - time.perf_counter()
+            if remaining <= 0:
+                return
+
+            time.sleep(min(remaining, 0.01))
 
     def _ceildiv(self, a, b) -> int:
         """Divides a by b and rounds up

--- a/src/utils/duplicate_capture.py
+++ b/src/utils/duplicate_capture.py
@@ -1,0 +1,44 @@
+from collections.abc import Callable
+from typing import TypeVar
+
+from enums.log_level import LogLevel
+
+Stats = TypeVar("Stats")
+MAX_DUPLICATE_CAPTURE_RETRIES = 2
+
+
+def recover_duplicate_capture(
+    capture_stats: Callable[[], tuple[Stats, bytes]],
+    previous_panel_bytes: bytes | None,
+    item_id: int,
+    log: Callable[[str, LogLevel], None],
+    sleep: Callable[[float], None],
+    retry_delay: float,
+) -> tuple[Stats, bytes]:
+    """Capture stats and retry when the panel is byte-identical to the previous item."""
+    stats, panel_bytes = capture_stats()
+    if previous_panel_bytes is None or panel_bytes != previous_panel_bytes:
+        return stats, panel_bytes
+
+    for retry in range(1, MAX_DUPLICATE_CAPTURE_RETRIES + 1):
+        log(
+            f"Item UID {item_id}: Duplicate stats capture detected. "
+            f"Retrying... ({retry}/{MAX_DUPLICATE_CAPTURE_RETRIES})",
+            LogLevel.WARNING,
+        )
+        sleep(retry_delay)
+
+        stats, panel_bytes = capture_stats()
+        if panel_bytes != previous_panel_bytes:
+            log(
+                f"Item UID {item_id}: Duplicate stats capture recovered on retry {retry}.",
+                LogLevel.DEBUG,
+            )
+            return stats, panel_bytes
+
+    log(
+        f"Item UID {item_id}: Duplicate stats capture persisted after retries. "
+        "Continuing with latest capture.",
+        LogLevel.WARNING,
+    )
+    return stats, panel_bytes

--- a/src/utils/ocr.py
+++ b/src/utils/ocr.py
@@ -51,7 +51,6 @@ def image_to_string(
     force_preprocess=False,
     preprocess_func=preprocess_img,
     remove_newline=True,
-    lang=None,
 ) -> str:
     """Convert image to string
 
@@ -62,61 +61,18 @@ def image_to_string(
     :param preprocess_func: The preprocessing function to use, defaults to None
     :return: The string representation of the image
     """
-    if lang is None:
-        lang = DIN_ALTERNATE
-
     tessdata_dir = resource_path("assets/tesseract/tessdata")
-
-    # Check which requested languages are bundled locally.
-    available_langs = []
-    for l in lang.split("+"):
-        if os.path.exists(os.path.join(tessdata_dir, f"{l}.traineddata")):
-            available_langs.append(l)
-
-    # Local OCR attempt uses bundled tessdata first.
-    final_lang = "+".join(available_langs) if available_langs else DIN_ALTERNATE
-    local_config = f'--tessdata-dir "{tessdata_dir}" -c tessedit_char_whitelist="{whitelist}" --psm {psm}'
-    system_config = f'-c tessedit_char_whitelist="{whitelist}" --psm {psm}'
-
-    # If local tessdata is missing requested languages (e.g. eng), try system tessdata as fallback.
-    attempts: list[tuple[str, str]] = [(local_config, final_lang)]
-    if lang != final_lang:
-        attempts.append((system_config, lang))
-    if "eng" in lang.split("+"):
-        attempts.append((system_config, "eng"))
-
-    # Keep original order while removing duplicates.
-    dedup_attempts = []
-    seen_attempts = set()
-    for config, config_lang in attempts:
-        key = (config, config_lang)
-        if key not in seen_attempts:
-            seen_attempts.add(key)
-            dedup_attempts.append((config, config_lang))
-
-    def _ocr_with_fallback(target_img: Image) -> str:
-        last_res = ""
-        for config, config_lang in dedup_attempts:
-            try:
-                last_res = pytesseract.image_to_string(
-                    target_img, config=config, lang=config_lang
-                )
-            except Exception:
-                # Continue to the next OCR source if this language/config is unavailable.
-                continue
-
-            if last_res.strip():
-                return last_res
-
-        return last_res
+    config = f'--tessdata-dir "{tessdata_dir}" -c tessedit_char_whitelist="{whitelist}" --psm {psm}'
 
     res = ""
     with OCR_SEMAPHORE:
         if not force_preprocess:
-            res = _ocr_with_fallback(img)
+            res = pytesseract.image_to_string(img, config=config, lang=DIN_ALTERNATE)
 
         if not res.strip():
-            res = _ocr_with_fallback(preprocess_func(img))
+            res = pytesseract.image_to_string(
+                preprocess_func(img), config=config, lang=DIN_ALTERNATE
+            )
 
     if remove_newline:
         res = res.replace("\n", " ")

--- a/src/utils/screenshot.py
+++ b/src/utils/screenshot.py
@@ -71,6 +71,18 @@ class Screenshot:
         :raises ValueError: Thrown if the scan type is invalid
         :return: A dict of the stats with the key being the stat name and the value being the screenshot
         """
+        stats, _ = self.screenshot_stats_with_panel_bytes(scan_type)
+        return stats
+
+    def screenshot_stats_with_panel_bytes(
+        self, scan_type: IncrementType
+    ) -> tuple[dict, bytes]:
+        """Takes a stats screenshot and returns its panel bytes for duplicate detection.
+
+        :param scan_type: The scan type
+        :raises ValueError: Thrown if the scan type is invalid
+        :return: The cropped stats dict and raw bytes of the full stats panel
+        """
         match IncrementType(scan_type):
             case IncrementType.LIGHT_CONE_ADD:
                 return self._screenshot_stats("light_cone")
@@ -78,7 +90,6 @@ class Screenshot:
                 return self._screenshot_stats("relic")
             case _:
                 raise ValueError(f"Invalid scan type: {scan_type.name}.")
-
     def screenshot_sort(self) -> Image:
         """Takes a screenshot of the current sort option. Requires inventory to be open.
 
@@ -211,15 +222,16 @@ class Screenshot:
 
         return screenshot
 
-    def _screenshot_stats(self, key: str) -> dict:
+    def _screenshot_stats(self, key: str) -> tuple[dict, bytes]:
         """Takes a screenshot of the stats
 
         :param key: The key of the stats to screenshot
-        :return: A dict of the stats with the key being the stat name and the value being the screenshot
+        :return: The cropped stats dict and raw bytes of the full stats panel
         """
         coords = SCREENSHOT_COORDS[self._aspect_ratio]
 
         img = self._take_screenshot(*coords[STATS])
+        panel_bytes = img.tobytes()
 
         adjusted_stat_coords = {
             k: (
@@ -233,7 +245,7 @@ class Screenshot:
 
         res = {k: img.crop(v) for k, v in adjusted_stat_coords.items()}
 
-        return res
+        return res, panel_bytes
 
     def _screenshot_traces(self, key: str) -> dict:
         """Takes a screenshot of the trace levels

--- a/tests/test_duplicate_stats_capture.py
+++ b/tests/test_duplicate_stats_capture.py
@@ -1,0 +1,150 @@
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from enums.log_level import LogLevel  # noqa: E402
+from utils.duplicate_capture import recover_duplicate_capture  # noqa: E402
+
+
+class FakeScreenshot:
+    def __init__(self, captures: list[tuple[dict, bytes]]) -> None:
+        self._captures = captures
+        self.calls = 0
+
+    def capture_stats(self) -> tuple[dict, bytes]:
+        capture = self._captures[min(self.calls, len(self._captures) - 1)]
+        self.calls += 1
+        return capture
+
+
+def recover(
+    captures: list[tuple[dict, bytes]], previous_bytes: bytes | None, item_id: int
+) -> tuple[tuple[dict, bytes], FakeScreenshot, list, list]:
+    screenshot = FakeScreenshot(captures)
+    logs = []
+    sleeps = []
+    result = recover_duplicate_capture(
+        screenshot.capture_stats,
+        previous_bytes,
+        item_id,
+        lambda msg, level: logs.append((msg, level)),
+        lambda seconds: sleeps.append(seconds),
+        0.15,
+    )
+    return result, screenshot, logs, sleeps
+
+
+class DuplicateStatsCaptureTest(unittest.TestCase):
+    def test_no_duplicate_captures_once(self) -> None:
+        (stats, panel_bytes), screenshot, logs, sleeps = recover(
+            [({"id": 1}, b"current")], b"previous", 1
+        )
+
+        self.assertEqual(stats, {"id": 1})
+        self.assertEqual(panel_bytes, b"current")
+        self.assertEqual(screenshot.calls, 1)
+        self.assertEqual(logs, [])
+        self.assertEqual(sleeps, [])
+
+    def test_duplicate_fixed_by_wait(self) -> None:
+        (stats, panel_bytes), screenshot, logs, sleeps = recover(
+            [({"id": "stale"}, b"previous"), ({"id": "fresh"}, b"fresh")],
+            b"previous",
+            2,
+        )
+
+        self.assertEqual(stats, {"id": "fresh"})
+        self.assertEqual(panel_bytes, b"fresh")
+        self.assertEqual(screenshot.calls, 2)
+        self.assertEqual(sleeps, [0.15])
+        self.assertIn(LogLevel.WARNING, [level for _, level in logs])
+
+    def test_duplicate_fixed_by_second_wait(self) -> None:
+        (stats, panel_bytes), screenshot, logs, sleeps = recover(
+            [
+                ({"id": "stale1"}, b"previous"),
+                ({"id": "stale2"}, b"previous"),
+                ({"id": "fresh"}, b"fresh"),
+            ],
+            b"previous",
+            3,
+        )
+
+        self.assertEqual(stats, {"id": "fresh"})
+        self.assertEqual(panel_bytes, b"fresh")
+        self.assertEqual(screenshot.calls, 3)
+        self.assertEqual(sleeps, [0.15, 0.15])
+        self.assertIn(LogLevel.WARNING, [level for _, level in logs])
+
+    def test_persistent_duplicate_caps_retries_and_continues(self) -> None:
+        (stats, panel_bytes), screenshot, logs, sleeps = recover(
+            [
+                ({"id": "stale1"}, b"previous"),
+                ({"id": "stale2"}, b"previous"),
+                ({"id": "stale3"}, b"previous"),
+            ],
+            b"previous",
+            4,
+        )
+
+        self.assertEqual(stats, {"id": "stale3"})
+        self.assertEqual(panel_bytes, b"previous")
+        self.assertEqual(screenshot.calls, 3)
+        self.assertEqual(sleeps, [0.15, 0.15])
+        warning_logs = [msg for msg, level in logs if level == LogLevel.WARNING]
+        self.assertEqual(len(warning_logs), 3)
+        self.assertIn("persisted after retries", warning_logs[-1])
+
+
+class DebugRunDuplicateCaptureTest(unittest.TestCase):
+    def test_known_debug_run_duplicate_pair(self) -> None:
+        debug_run = os.environ.get("HSR_DEBUG_RUN")
+        if not debug_run:
+            self.skipTest("Set HSR_DEBUG_RUN to validate captured debug screenshots.")
+
+        folder = Path(debug_run)
+        log_path = folder / "log.txt"
+        if not log_path.exists():
+            self.skipTest(f"Missing debug log: {log_path}")
+
+        save_names = []
+        for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+            match = re.search(r"Saving (\d+\.png)", line)
+            if match:
+                save_names.append(match.group(1))
+
+        from PIL import Image
+
+        def raw_panel_bytes(index: int) -> bytes:
+            with Image.open(folder / save_names[index]) as img:
+                img.load()
+                return img.tobytes()
+
+        self.assertGreater(len(save_names), 48)
+        # In this debug run, first saves are quantity/sort; item N maps to save_names[N + 1].
+        relic_45 = raw_panel_bytes(46)
+        relic_46 = raw_panel_bytes(47)
+        relic_47 = raw_panel_bytes(48)
+
+        self.assertEqual(relic_45, relic_46)
+        self.assertNotEqual(relic_46, relic_47)
+
+        (stats, panel_bytes), screenshot, logs, sleeps = recover(
+            [({"id": "relic_46"}, relic_46), ({"id": "relic_47"}, relic_47)],
+            relic_45,
+            46,
+        )
+
+        self.assertEqual(stats, {"id": "relic_47"})
+        self.assertEqual(panel_bytes, relic_47)
+        self.assertEqual(screenshot.calls, 2)
+        self.assertEqual(sleeps, [0.15])
+        self.assertIn(LogLevel.WARNING, [level for _, level in logs])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Solves two relic scanning issues I ran into:

- Detects active relic lock state from the lock icon’s rendered colors instead of relying on generic icon matching.
- Detects byte-identical consecutive relic stats-panel captures and retries before OCR, preventing stale duplicate relic data from being assigned to the next UID.

Plus two OCR fixes found while validating scans:

- Widens the relic level crop so single-digit "+0" levels are fully captured.
- Removes the separate-language (eng) OCR fallback, which could never load a language in released builds and only cost failed Tesseract spawns.

## Details

### Relic lock detection

The relic lock icon uses an active gold/white/dark color pattern that could fail through the generic icon matching path. This PR adds relic-specific lock-state parsing using color ratios from the cropped lock icon. The lock crop was also slightly adjusted to better center the icon.

### Duplicate stats-panel capture recovery

During inventory walking, adjacent relic UIDs can occasionally receive byte-identical stats-panel screenshots. Local testing showed a roughly 0.1%-0.5% duplicate rate on my machine. When this happens, the scanner now:

- compares the raw full stats-panel pixel bytes against the previous accepted capture
- logs a warning when a duplicate is detected
- waits briefly and retries capture
- gives up after capped retries to avoid infinite loops

### Relic level crop

The relic level crop started at x=0.115, which bisects single-digit "+0" levels and only OCRed correctly by luck when the panel background fell outside the white color filter. The left edge now starts at x=0.03 so the full digit is always captured.

### Separate-language OCR fallback removal

Relic name and level OCR requested `eng+DIN-Alternate`, but `eng.traineddata` is not bundled in releases, so the fallback chain only ever spawned Tesseract processes that were guaranteed to fail (~160ms each) whenever the primary attempt came back empty. The "system tessdata" attempts could never rescue this either — `TESSDATA_PREFIX` is pinned to the bundled directory, so they searched the same place that lacked eng to begin with. A review of 2.8k scanned relics showed no accuracy loss without eng: the handful of imperfect name reads were all corrected by the existing fuzzy matching against known relic names. OCR is now a single DIN-Alternate pass against bundled tessdata. If bundling eng is ever desired later, it's a spec-file addition plus re-adding the lang argument at the call sites.

## Validation

- Added focused unit tests for duplicate stats-panel recovery, covering normal captures, successful retries, and capped persistent duplicates.
- Rebuilt and ran scanner debug passes against real relic inventory data.
- Confirmed duplicate stats-panel captures were logged, retried, and recovered during real scans.
- Confirmed recovered runs completed without relic parse errors caused by stale duplicate captures.
- Verified single-pass OCR reads sample relic level/mainstat crops correctly after the fallback removal.